### PR TITLE
Enable setBeforeGet for grouped-accessor-pairs rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports = {
     "func-name-matching": "error",
     "func-names": "off",
     "func-style": "off",
-    "grouped-accessor-pairs": "error",
+    "grouped-accessor-pairs": ["error", "setBeforeGet"],
     "guard-for-in": "off",
     "id-denylist": "off",
     "id-length": "off",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/eslint-config",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://playcanvas.com",
   "description": "ESLint configuration used by PlayCanvas",


### PR DESCRIPTION
Tighten up the [grouped-accessor-pairs](https://eslint.org/docs/rules/grouped-accessor-pairs) rule by enabling the [`setBeforeGet`](https://eslint.org/docs/rules/grouped-accessor-pairs#setbeforeget) option.

This has two benefits:

1. The codebase currently has instances of getters before setters **and** setters before getters. So this brings consistency.
2. When generating TypeScript declarations, both getter and setter appear **after** the corresponding JSDoc block. If a getter appears before a setter, the order is: getter, JSDoc block, setter (which is difficult to read).