### PR TITLE
Update JSDoc plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = {
 
   "parserOptions": {
-    "ecmaVersion": 2015,
+    "ecmaVersion": "latest",
     "sourceType": "module",
     "ecmaFeatures": {}
   },
@@ -384,24 +384,20 @@ module.exports = {
     "jsdoc/check-alignment": "error",
     "jsdoc/check-examples": "off",
     "jsdoc/check-indentation": "off",
-    "jsdoc/check-line-alignment": "off",
+    "jsdoc/check-line-alignment": "error",
     "jsdoc/check-param-names": "off",
     "jsdoc/check-property-names": "error",
     "jsdoc/check-syntax": "error",
-    "jsdoc/check-tag-names": [
-      "error", {
-        "definedTags": ["component", "field"]
-      }
-    ],
+    "jsdoc/check-tag-names": "error",
     "jsdoc/check-types": "error",
     "jsdoc/check-values": "error",
     "jsdoc/empty-tags": "error",
     "jsdoc/implements-on-classes": "error",
     "jsdoc/match-description": "off",
     "jsdoc/match-name": "off",
-    "jsdoc/multiline-blocks": "off",
+    "jsdoc/multiline-blocks": "error",
     "jsdoc/newline-after-description": "error",
-    "jsdoc/no-bad-blocks": "off",
+    "jsdoc/no-bad-blocks": "error",
     "jsdoc/no-defaults": "off",
     "jsdoc/no-missing-syntax": "off",
     "jsdoc/no-multi-asterisks": "error",
@@ -432,8 +428,8 @@ module.exports = {
     "jsdoc/require-returns-type": "error",
     "jsdoc/require-returns": "error",
     "jsdoc/require-throws": "off",
-    "jsdoc/require-yields": "off",
-    "jsdoc/require-yields-check": "off",
+    "jsdoc/require-yields": "error",
+    "jsdoc/require-yields-check": "error",
     "jsdoc/tag-lines": "off",
     "jsdoc/valid-types": "off"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,28 +1,28 @@
 {
   "name": "@playcanvas/eslint-config",
-  "version": "1.0.14",
+  "version": "1.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@playcanvas/eslint-config",
-      "version": "1.0.14",
+      "version": "1.0.16",
       "license": "MIT",
       "dependencies": {
-        "eslint-plugin-jsdoc": "^37.1.0"
+        "eslint-plugin-jsdoc": "^37.5.1"
       },
       "peerDependencies": {
         "eslint": ">= 4"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.12.0.tgz",
-      "integrity": "sha512-Gw4/j9v36IKY8ET+W0GoOzrRw17xjf21EIFFRL3zx21fF5MnqmeNpNi+PU/LKjqLpPb2Pw2XdlJbYM31VVo/PQ==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.14.2.tgz",
+      "integrity": "sha512-812igKXDcLEdkwUbJvnhzMy88dBBiDeaf3mMF1jnQwclIObu5UQB8ow1KAvDRN1FQqpB+IsZnpmRA0jZ6KGt3g==",
       "dependencies": {
-        "comment-parser": "1.2.4",
+        "comment-parser": "1.3.0",
         "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "2.0.0"
+        "jsdoc-type-pratt-parser": "2.0.2"
       },
       "engines": {
         "node": "^12 || ^14 || ^16 || ^17"
@@ -204,9 +204,9 @@
       "peer": true
     },
     "node_modules/comment-parser": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.4.tgz",
-      "integrity": "sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
+      "integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==",
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -344,16 +344,16 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "37.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.1.0.tgz",
-      "integrity": "sha512-DpkFzX5Sqkqzy4MCgowhDXmusWcF1Gn7wYnphdGfWmIkoQr6SwL0jEtltGAVyF5Rj6ACi6ydw0oCCI5hF3yz6w==",
+      "version": "37.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.5.1.tgz",
+      "integrity": "sha512-WMv/Na5QdpMQao1MR3SgYpGFi2PSrhh/JljlErQru9ZYXf1j9oQVIVCELQV7jcyqKQ/svPqCyU8eMhet9dzP+w==",
       "dependencies": {
-        "@es-joy/jsdoccomment": "0.12.0",
+        "@es-joy/jsdoccomment": "0.14.2",
         "comment-parser": "1.3.0",
         "debug": "^4.3.3",
         "escape-string-regexp": "^4.0.0",
         "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "^2.0.0",
+        "jsdoc-type-pratt-parser": "^2.0.2",
         "regextras": "^0.8.0",
         "semver": "^7.3.5",
         "spdx-expression-parse": "^3.0.1"
@@ -363,14 +363,6 @@
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/comment-parser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
-      "integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==",
-      "engines": {
-        "node": ">= 12.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -683,9 +675,9 @@
       }
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.0.0.tgz",
-      "integrity": "sha512-sUuj2j48wxrEpbFjDp1sAesAxPiLT+z0SWVmMafyIINs6Lj5gIPKh3VrkBZu4E/Dv+wHpOot0m6H8zlHQjwqeQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.0.2.tgz",
+      "integrity": "sha512-gXN5CxeaI9WtYQYzpOO/CtTRfZppQlKxXRTIm73JuAX6kOGTQ7iZ0e+YB+b2m7Fk+gTYYxRtE1nqje7H6dqv8w==",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -1055,13 +1047,13 @@
   },
   "dependencies": {
     "@es-joy/jsdoccomment": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.12.0.tgz",
-      "integrity": "sha512-Gw4/j9v36IKY8ET+W0GoOzrRw17xjf21EIFFRL3zx21fF5MnqmeNpNi+PU/LKjqLpPb2Pw2XdlJbYM31VVo/PQ==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.14.2.tgz",
+      "integrity": "sha512-812igKXDcLEdkwUbJvnhzMy88dBBiDeaf3mMF1jnQwclIObu5UQB8ow1KAvDRN1FQqpB+IsZnpmRA0jZ6KGt3g==",
       "requires": {
-        "comment-parser": "1.2.4",
+        "comment-parser": "1.3.0",
         "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "2.0.0"
+        "jsdoc-type-pratt-parser": "2.0.2"
       }
     },
     "@eslint/eslintrc": {
@@ -1198,9 +1190,9 @@
       "peer": true
     },
     "comment-parser": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.4.tgz",
-      "integrity": "sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
+      "integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1303,26 +1295,19 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "37.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.1.0.tgz",
-      "integrity": "sha512-DpkFzX5Sqkqzy4MCgowhDXmusWcF1Gn7wYnphdGfWmIkoQr6SwL0jEtltGAVyF5Rj6ACi6ydw0oCCI5hF3yz6w==",
+      "version": "37.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.5.1.tgz",
+      "integrity": "sha512-WMv/Na5QdpMQao1MR3SgYpGFi2PSrhh/JljlErQru9ZYXf1j9oQVIVCELQV7jcyqKQ/svPqCyU8eMhet9dzP+w==",
       "requires": {
-        "@es-joy/jsdoccomment": "0.12.0",
+        "@es-joy/jsdoccomment": "0.14.2",
         "comment-parser": "1.3.0",
         "debug": "^4.3.3",
         "escape-string-regexp": "^4.0.0",
         "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "^2.0.0",
+        "jsdoc-type-pratt-parser": "^2.0.2",
         "regextras": "^0.8.0",
         "semver": "^7.3.5",
         "spdx-expression-parse": "^3.0.1"
-      },
-      "dependencies": {
-        "comment-parser": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
-          "integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA=="
-        }
       }
     },
     "eslint-scope": {
@@ -1559,9 +1544,9 @@
       }
     },
     "jsdoc-type-pratt-parser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.0.0.tgz",
-      "integrity": "sha512-sUuj2j48wxrEpbFjDp1sAesAxPiLT+z0SWVmMafyIINs6Lj5gIPKh3VrkBZu4E/Dv+wHpOot0m6H8zlHQjwqeQ=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.0.2.tgz",
+      "integrity": "sha512-gXN5CxeaI9WtYQYzpOO/CtTRfZppQlKxXRTIm73JuAX6kOGTQ7iZ0e+YB+b2m7Fk+gTYYxRtE1nqje7H6dqv8w=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/eslint-config",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://playcanvas.com",
   "description": "ESLint configuration used by PlayCanvas",
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "dependencies": {
-    "eslint-plugin-jsdoc": "^37.1.0"
+    "eslint-plugin-jsdoc": "^37.5.1"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
* Bump `eslint-plugin-jsdoc` from `37.1.0` to `37.5.1`.
* Tighten up some JSDoc related rules.
* Change the default parser to `latest` instead of `2015`.
