### PR TITLE
Update from ES6 to ES2020 to add support for BigInt

### DIFF
--- a/index.js
+++ b/index.js
@@ -465,7 +465,7 @@ module.exports = {
 
   "env": {
     "browser": true,
-    "es6": true,
+    "es2020": true,
     "node": true,
     "worker": true
   }

--- a/index.js
+++ b/index.js
@@ -405,7 +405,7 @@ module.exports = {
     "jsdoc/check-property-names": "error",
     "jsdoc/check-syntax": "error",
     "jsdoc/check-tag-names": "error",
-    "jsdoc/check-types": "error",
+    "jsdoc/check-types": "off",
     "jsdoc/check-values": "error",
     "jsdoc/empty-tags": "error",
     "jsdoc/implements-on-classes": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playcanvas/eslint-config",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@playcanvas/eslint-config",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "eslint-plugin-import": "^2.27.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/eslint-config",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://playcanvas.com",
   "description": "ESLint configuration used by PlayCanvas",


### PR DESCRIPTION
Big Int is used on WebGPU Queries, required here: https://github.com/playcanvas/engine/pull/5470

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array
https://futurestud.io/tutorials/eslint-how-to-fix-bigint-is-not-defined