### PR TITLE
Detect missing file extensions for browser compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,12 @@ module.exports = {
     "id-denylist": "off",
     "id-length": "off",
     "id-match": "off",
+    "import/extensions": [
+      "error", {
+        "js": "always",
+        "mjs": "always",
+      }
+    ],
     "init-declarations": "off",
     "max-classes-per-file": "off",
     "max-depth": "off",

--- a/index.js
+++ b/index.js
@@ -103,12 +103,6 @@ module.exports = {
     "id-denylist": "off",
     "id-length": "off",
     "id-match": "off",
-    "import/extensions": [
-      "error", {
-        "js": "always",
-        "mjs": "always",
-      }
-    ],
     "init-declarations": "off",
     "max-classes-per-file": "off",
     "max-depth": "off",
@@ -389,16 +383,19 @@ module.exports = {
 
     // Import rules
 
-    // Static Analysis
-    "import/no-unresolved": "error",
+    // Static analysis
+    "import/default": "error",
     "import/named": "error",
     "import/namespace": "error",
-    "import/default": "error",
-    "import/export": "error",
+    "import/no-unresolved": "error",
 
-    // Helpful Warnings
+    // Helpful warnings
+    "import/export": "error",
     "import/no-named-as-default": "warn",
     "import/no-named-as-default-member": "warn",
+
+    // Style guide
+    "import/extensions": ["error", "always"],
     "import/no-duplicates": "warn",
 
     // JSDoc rules


### PR DESCRIPTION
We use the file extensions `*.js` and `*.mjs` so far and for browser compatibility we require the full file name, including extension.

Usually @willeastcott found these cases, but one PR got through now:

![image](https://github.com/playcanvas/playcanvas-eslint-config/assets/5236548/4ea7dfb1-bda2-403d-9c18-fae9f6f0c979)

More details about the ESLint rule can be found here: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/extensions.md