### PR TITLE
Stricter ESLint config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.npmrc

--- a/index.js
+++ b/index.js
@@ -6,10 +6,6 @@ module.exports = {
     "ecmaFeatures": {}
   },
 
-  "extends": [
-    "plugin:regexp/recommended"
-  ],
-
   // Rules reference: https://eslint.org/docs/rules/
   "rules": {
     // Possible Problems
@@ -465,12 +461,82 @@ module.exports = {
     "jsdoc/sort-tags": "off",
     "jsdoc/tag-lines": "off",
     "jsdoc/text-escaping": "off",
-    "jsdoc/valid-types": "off"
+    "jsdoc/valid-types": "off",
+
+    // Regex rules
+    "no-control-regex": "error",
+    "no-misleading-character-class": "error",
+    "no-regex-spaces": "error",
+    "prefer-regex-literals": "error",
+    "no-invalid-regexp": "off",
+    "no-useless-backreference": "off",
+    "no-empty-character-class": "off",
+    "regexp/confusing-quantifier": "warn",
+    "regexp/control-character-escape": "error",
+    "regexp/match-any": "error",
+    "regexp/negation": "error",
+    "regexp/no-contradiction-with-assertion": "error",
+    "regexp/no-dupe-characters-character-class": "error",
+    "regexp/no-dupe-disjunctions": "error",
+    "regexp/no-empty-alternative": "warn",
+    "regexp/no-empty-capturing-group": "error",
+    "regexp/no-empty-character-class": "error",
+    "regexp/no-empty-group": "error",
+    "regexp/no-empty-lookarounds-assertion": "error",
+    "regexp/no-empty-string-literal": "error",
+    "regexp/no-escape-backspace": "error",
+    "regexp/no-extra-lookaround-assertions": "error",
+    "regexp/no-invalid-regexp": "error",
+    "regexp/no-invisible-character": "error",
+    "regexp/no-lazy-ends": "warn",
+    "regexp/no-legacy-features": "error",
+    "regexp/no-misleading-capturing-group": "error",
+    "regexp/no-misleading-unicode-character": "error",
+    "regexp/no-missing-g-flag": "error",
+    "regexp/no-non-standard-flag": "error",
+    "regexp/no-obscure-range": "error",
+    "regexp/no-optional-assertion": "error",
+    "regexp/no-potentially-useless-backreference": "warn",
+    "regexp/no-super-linear-backtracking": "error",
+    "regexp/no-trivially-nested-assertion": "error",
+    "regexp/no-trivially-nested-quantifier": "error",
+    "regexp/no-unused-capturing-group": "error",
+    "regexp/no-useless-assertions": "error",
+    "regexp/no-useless-backreference": "error",
+    "regexp/no-useless-character-class": "error",
+    "regexp/no-useless-dollar-replacements": "error",
+    "regexp/no-useless-escape": "error",
+    "regexp/no-useless-flag": "warn",
+    "regexp/no-useless-lazy": "error",
+    "regexp/no-useless-non-capturing-group": "error",
+    "regexp/no-useless-quantifier": "error",
+    "regexp/no-useless-range": "error",
+    "regexp/no-useless-set-operand": "error",
+    "regexp/no-useless-string-literal": "error",
+    "regexp/no-useless-two-nums-quantifier": "error",
+    "regexp/no-zero-quantifier": "error",
+    "regexp/optimal-lookaround-quantifier": "warn",
+    "regexp/optimal-quantifier-concatenation": "error",
+    "regexp/prefer-character-class": "error",
+    "regexp/prefer-d": "error",
+    "regexp/prefer-plus-quantifier": "error",
+    "regexp/prefer-predefined-assertion": "error",
+    "regexp/prefer-question-quantifier": "error",
+    "regexp/prefer-range": "error",
+    "regexp/prefer-set-operation": "error",
+    "regexp/prefer-star-quantifier": "error",
+    "regexp/prefer-unicode-codepoint-escapes": "error",
+    "regexp/prefer-w": "error",
+    "regexp/simplify-set-operations": "error",
+    "regexp/sort-flags": "error",
+    "regexp/strict": "error",
+    "regexp/use-ignore-case": "error",
   },
 
   "plugins": [
     "import",
-    "jsdoc"
+    "jsdoc",
+    "regexp"
   ],
 
   "settings": {

--- a/index.js
+++ b/index.js
@@ -414,7 +414,7 @@ module.exports = {
     "jsdoc/check-param-names": "off",
     "jsdoc/check-property-names": "error",
     "jsdoc/check-syntax": "error",
-    "jsdoc/check-tag-names": "error",
+    "jsdoc/check-tag-names": ["error", { "definedTags": ["import"] }],
     "jsdoc/check-types": "off",
     "jsdoc/check-values": "error",
     "jsdoc/empty-tags": "error",

--- a/index.js
+++ b/index.js
@@ -6,6 +6,10 @@ module.exports = {
     "ecmaFeatures": {}
   },
 
+  "extends": [
+    "plugin:regexp/recommended"
+  ],
+
   // Rules reference: https://eslint.org/docs/rules/
   "rules": {
     // Possible Problems
@@ -90,7 +94,7 @@ module.exports = {
     "complexity": "off",
     "consistent-return": "off",
     "consistent-this": "off",
-    "curly": "off",
+    "curly": ["error", "multi-line"],
     "default-case": "off",
     "default-case-last": "off",
     "default-param-last": "off",
@@ -205,7 +209,7 @@ module.exports = {
     "one-var": "off",
     "one-var-declaration-per-line": "off",
     "operator-assignment": ["error", "always"],
-    "prefer-arrow-callback": "off",
+    "prefer-arrow-callback": "error",
     "prefer-const": "error",
     "prefer-destructuring": "off",
     "prefer-exponentiation-operator": "off",
@@ -217,7 +221,7 @@ module.exports = {
     "prefer-regex-literals": "off",
     "prefer-rest-params": "off",
     "prefer-spread": "warn",
-    "prefer-template": "off",
+    "prefer-template": "error",
     "quote-props": "off",
     "radix": "error",
     "require-await": "error",
@@ -266,10 +270,10 @@ module.exports = {
     "implicit-arrow-linebreak": "error",
     "indent": [
       "error", 4, {
+        "CallExpression": { "arguments": "first" },
+        "FunctionExpression": { "body": 1, "parameters": 2 },
+        "MemberExpression": 0,
         "SwitchCase": 1,
-        "CallExpression": {
-          "arguments": "first"
-        },
         "ignoreComments": true
       }
     ],
@@ -390,6 +394,11 @@ module.exports = {
     "import/named": "error",
     "import/namespace": "error",
     "import/no-unresolved": "error",
+    "import/order": ["error", {
+      "groups": ["builtin", "external", "internal", ["parent", "sibling"], "index", "unknown"],
+      "newlines-between": "always",
+      "alphabetize": { "order": "asc", "caseInsensitive": true }
+    }],
 
     // Helpful warnings
     "import/export": "error",

--- a/index.js
+++ b/index.js
@@ -340,7 +340,7 @@ module.exports = {
       }
     ],
     "padding-line-between-statements": "off",
-    "quotes": ["off", "single"],
+    "quotes": ["error", "single"],
     "rest-spread-spacing": "error",
     "semi": ["error", "always"],
     "semi-spacing": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "eslint-plugin-import": "^2.28.0",
-        "eslint-plugin-jsdoc": "^46.4.6"
+        "eslint-plugin-jsdoc": "^46.4.6",
+        "eslint-plugin-regexp": "^2.6.0"
       },
       "peerDependencies": {
         "eslint": ">= 4"
@@ -42,7 +43,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
       "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
-      "peer": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.3.0"
       },
@@ -54,10 +54,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
-      "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
-      "peer": true,
+      "version": "4.11.0",
+      "resolved": "https://registry.snapchat.com/node/virtual/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
+      "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -792,6 +791,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/eslint-plugin-regexp": {
+      "version": "2.6.0",
+      "resolved": "https://registry.snapchat.com/node/virtual/eslint-plugin-regexp/-/eslint-plugin-regexp-2.6.0.tgz",
+      "integrity": "sha512-FCL851+kislsTEQEMioAlpDuK5+E5vs0hi1bF8cFlPlHcEjeRhuAzEsGikXRreE+0j4WhW2uO54MqTjXtYOi3A==",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.9.1",
+        "comment-parser": "^1.4.0",
+        "jsdoc-type-pratt-parser": "^4.0.0",
+        "refa": "^0.12.1",
+        "regexp-ast-analysis": "^0.7.1",
+        "scslre": "^0.3.0"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.44.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -812,7 +831,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -1803,6 +1821,29 @@
       ],
       "peer": true
     },
+    "node_modules/refa": {
+      "version": "0.12.1",
+      "resolved": "https://registry.snapchat.com/node/virtual/refa/-/refa-0.12.1.tgz",
+      "integrity": "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/regexp-ast-analysis": {
+      "version": "0.7.1",
+      "resolved": "https://registry.snapchat.com/node/virtual/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
+      "integrity": "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.1"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
@@ -1920,6 +1961,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/scslre": {
+      "version": "0.3.0",
+      "resolved": "https://registry.snapchat.com/node/virtual/scslre/-/scslre-0.3.0.tgz",
+      "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.0",
+        "regexp-ast-analysis": "^0.7.0"
+      },
+      "engines": {
+        "node": "^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   ],
   "dependencies": {
     "eslint-plugin-import": "^2.28.0",
-    "eslint-plugin-jsdoc": "^46.4.6"
+    "eslint-plugin-jsdoc": "^46.4.6",
+    "eslint-plugin-regexp": "^2.6.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Fixes #10 

- Added prefer arrow callback
- Added curly error
- Added import ordering
- Added recommended Regex rules
- Added ignore for `@import` tag
- Added quotes rule enforcing single quotes